### PR TITLE
Fix NativeWind babel preset usage

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,8 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
+    presets: ['babel-preset-expo', 'nativewind/babel'],
     plugins: [
-      'nativewind/babel', // <-- 👈 Add this line
       [
         'module-resolver',
         {


### PR DESCRIPTION
## Summary
- fix plugin configuration for NativeWind in `babel.config.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npx expo --version`
- `CI=1 npx expo export --output-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68794d6e5ca0832482401b949756a7a1