### PR TITLE
Fix sparkle animation path

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -28,7 +28,7 @@ export default function Home() {
       {/* Sparkle overlay */}
       <LottieView
         ref={sparkleRef}
-        source={require('@/assets/animations/sparkle.json')}
+        source={require('@/assets/sparkle.json')}
         autoPlay
         loop
         style={styles.sparkles}

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -1,1 +1,1 @@
-export const BG_IMAGE = require('@/assets/images/bg-dark.png') // Easily swappable
+export const BG_IMAGE = require('../../assets/images/bg-dark.png') // Easily swappable


### PR DESCRIPTION
## Summary
- fix Lottie asset path
- reference correct background image

## Testing
- `npm test --silent` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68795aa60afc8324ae5fd7307c7ee9f4